### PR TITLE
Menumulti - menu dinâmico com múltiplas entraqdas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
     "autoload": {
         "psr-4": {
             "Uspdev\\UspTheme\\": "src"
-        }
+        },
+        "files": [
+            "app/helpers.php"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
             "Uspdev\\UspTheme\\": "src"
         },
         "files": [
-            "app/helpers.php"
+            "src/helpers.php"
         ]
     }
 }

--- a/src/UspTheme.php
+++ b/src/UspTheme.php
@@ -59,7 +59,9 @@ class UspTheme
             }
 
             if (\has_string_keys($item)) { // registro (array simples)
-                $item = SELF::evaluateCan($item); // pode retornar null
+                if (!$item = SELF::evaluateCan($item)) { // pode retornar null
+                    continue;
+                };
                 $item = SELF::submenuAddRight($item);
                 $item = SELF::addActiveClass($item);
                 $item = SELF::parseTitleTarget($item);
@@ -67,7 +69,9 @@ class UspTheme
             } else { // coleção, vamos iterar sobre cada item
                 $itens = $item;
                 foreach ($itens as $item) {
-                    $item = SELF::evaluateCan($item); // pode retornar null
+                    if (!$item = SELF::evaluateCan($item)) { // pode retornar null
+                        continue;
+                    };
                     $item = SELF::submenuAddRight($item);
                     $item = SELF::addActiveClass($item);
                     $item = SELF::parseTitleTarget($item);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -2,6 +2,8 @@
 
 /**
  * Verifica se um array possui somente chaves numéricas
+ * 
+ * https://stackoverflow.com/questions/173400/how-to-check-if-php-array-is-associative-or-sequential/4254008#4254008
  */
 if (!function_exists('has_string_keys')) {
     function has_string_keys(array $array)

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Verifica se um array possui somente chaves numéricas
+ */
+if (!function_exists('has_string_keys')) {
+    function has_string_keys(array $array)
+    {
+        return count(array_filter(array_keys($array), 'is_string')) > 0;
+    }
+}


### PR DESCRIPTION
A idéia aqui é permitir que o menu dinâmico adicione mais de um menu. Hoje o menu dinâmico insere somente uma entrada.
Isso será útil, por exemplo, para o senhaunica-socialite criar um item de menu para os usuários e outro para o loginas.
Para isso basta passar como parâmetro no addMenu um array com múltiplos itens de menu.
Se for passado um único item (compatibilidade retroativa) também vai funcionar conrretamente.
