### PR TITLE
Correção de bug: deixa de consultar o Replicado para obter ramal se o usuário não estiver no replicado

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "git.useEditorAsCommitInput": false
-}

--- a/resources/views/partials/skins/ip/login_bar.blade.php
+++ b/resources/views/partials/skins/ip/login_bar.blade.php
@@ -31,15 +31,18 @@
     <!-- Vamos colocal o menu nesta posição -->
     </span>
     @auth
-    @if (isset(Auth::user()->role)) <strong>{{ Auth::user()->role }}</strong> - @endif
+        @if (isset(Auth::user()->role)) <strong>{{ Auth::user()->role }}</strong> - @endif
         @php
-            $ramal = \Uspdev\Replicado\Pessoa::obterRamalUsp(Auth::user()->codpes);
+            if (is_numeric(Auth::user()->codpes))
+                $ramal = \Uspdev\Replicado\Pessoa::obterRamalUsp(Auth::user()->codpes);
         @endphp
         @if (isset(Auth::user()->role)) <strong>{{ Auth::user()->role }}</strong> - @endif
         <i class="fas fa-user"></i> {{ Auth::user()->name }} &nbsp; 
         <i class="fas fa-envelope"></i> {{ Auth::user()->email }} &nbsp; 
-        <a class="text-white" href="https://uspdigital.usp.br/telefonia/" target="_blank" title="Se necessário, atualize seu ramal."><i class="fas fa-phone"></i> 
-            {{ !empty($ramal) ? $ramal : 'sem ramal' }}</a> |    
+        @if (is_numeric(Auth::user()->codpes))
+            <a class="text-white" href="https://uspdigital.usp.br/telefonia/" target="_blank" title="Se necessário, atualize seu ramal."><i class="fas fa-phone"></i> 
+                {{ !empty($ramal) ? $ramal : 'sem ramal' }}</a> |    
+        @endif
         @include('laravel-usp-theme::partials.login_bar.logout_link')
     @else
         Não autenticado |


### PR DESCRIPTION
No sistema impressoras, é possível criar usuários no banco de dados do sistema impressoras, ausentes no Replicado. Com isso, quando esse usuário loga no impressoras, o laravel-usp-theme consulta o Replicado para obter seu ramal e exibí-lo acima do menu, mas isso acarreta erro, pois não há um codpes numérico neste caso. Então, antes de realizar essa consulta, passo a fazer uma verificação do conteúdo do codpes.